### PR TITLE
Fix Discourse plugin to prevent installation failure

### DIFF
--- a/javascripts/discourse/api-initializers/composer-placeholder.js
+++ b/javascripts/discourse/api-initializers/composer-placeholder.js
@@ -1,5 +1,4 @@
 import { withPluginApi } from 'discourse/lib/plugin-api';
-import { observes } from '@ember/object';
 
 export default {
     name: 'composer-template-placeholder',
@@ -16,11 +15,8 @@ export default {
           init() {
             this._super(...arguments);
             this.setupPlaceholder();
+            this.addObserver('model.category', this, this.setPlaceholder);
           },
-          
-          categoryChanged: observes('model.category', function() {
-            this.setPlaceholder();
-          }),
           
           setPlaceholder() {
               if(!this.siteSettings.composer_template_placeholder_enabled) {

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,13 +2,11 @@
 # about: Adds template placeholders to the composer based on category templates
 # version: 1.0.0
 # authors: Steven
-# url: https://github.com/yourusername/discourse-composer-template-placeholder
+# url: https://github.com/bluefroguk1/discourse-placeholder
 # required_version: 2.7.0
 # transpile_js: true
 
 enabled_site_setting :composer_template_placeholder_enabled
-
-register_svg_icon "far-clipboard" if respond_to?(:register_svg_icon)
 
 register_asset 'stylesheets/common/composer-template-placeholder.scss'
 register_asset 'javascripts/discourse/api-initializers/composer-placeholder.js'

--- a/stylesheets/common/composer-template-placeholder.scss
+++ b/stylesheets/common/composer-template-placeholder.scss
@@ -1,1 +1,16 @@
-// Styles for composer template placeholder 
+/* Styles for composer template placeholder */
+
+.composer-placeholder {
+  font-style: italic;
+  color: #999;
+  padding: 10px;
+  border: 1px dashed #ccc;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+  margin-bottom: 10px;
+}
+
+.composer-placeholder::before {
+  content: "Template Placeholder: ";
+  font-weight: bold;
+}


### PR DESCRIPTION
Update the `plugin.rb` file to correct the GitHub repository URL and remove the unnecessary `register_svg_icon` line.

Update the `javascripts/discourse/api-initializers/composer-placeholder.js` file to remove the unnecessary `observes` import and replace the `categoryChanged` method with an `addObserver` call in the `init` method.

Add styles for the composer template placeholder in the `stylesheets/common/composer-template-placeholder.scss` file.

