### PR TITLE
Fix installation issues for Discourse plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This Discourse plugin adds template placeholders to the composer based on catego
 ## Installation
 
 Follow the [Install a Plugin](https://meta.discourse.org/t/install-a-plugin/19157) guide, using
-`git clone https://github.com/yourusername/discourse-composer-template-placeholder.git`
+`git clone https://github.com/bluefroguk1/discourse-placeholder.git`
 
 ## Configuration
 

--- a/javascripts/discourse/api-initializers/composer-placeholder.js
+++ b/javascripts/discourse/api-initializers/composer-placeholder.js
@@ -19,12 +19,12 @@ export default {
           },
           
           setPlaceholder() {
-              if(!this.siteSettings.composer_template_placeholder_enabled) {
+              if(!this.siteSettings.composer_template_placeholder_enabled?) {
                 return;
               }
               const category = this.model?.category;
               if (category?.topic_template) {
-                  this.model.set('replyPlaceholder', category.topic_template);
+                  this.model.set('replyPlaceholder', category.topic_template || null);
               } else {
                   this.model.set('replyPlaceholder', null);
               }

--- a/plugin.rb
+++ b/plugin.rb
@@ -4,12 +4,13 @@
 # authors: Steven
 # url: https://github.com/bluefroguk1/discourse-placeholder
 # required_version: 2.7.0
-# transpile_js: true
 
 enabled_site_setting :composer_template_placeholder_enabled
 
 register_asset 'stylesheets/common/composer-template-placeholder.scss'
 register_asset 'javascripts/discourse/api-initializers/composer-placeholder.js'
+register_asset 'config/locales/client.en.yml'
+register_asset 'config/locales/server.en.yml'
 
 after_initialize do
   # Add any server-side code here if needed


### PR DESCRIPTION
Update plugin to fix installation issues and improve functionality.

* **plugin.rb**
  - Remove `transpile_js: true` line.
  - Add `register_asset 'config/locales/client.en.yml'`.
  - Add `register_asset 'config/locales/server.en.yml'`.

* **javascripts/discourse/api-initializers/composer-placeholder.js**
  - Change `this.siteSettings.composer_template_placeholder_enabled` to `this.siteSettings.composer_template_placeholder_enabled?`.
  - Change `this.model.set('replyPlaceholder', category.topic_template)` to `this.model.set('replyPlaceholder', category.topic_template || null)`.

* **README.md**
  - Update the installation URL to `https://github.com/bluefroguk1/discourse-placeholder.git`.

