### PR TITLE
Fix plugin installation by correcting syntax error

### DIFF
--- a/javascripts/discourse/api-initializers/composer-placeholder.js
+++ b/javascripts/discourse/api-initializers/composer-placeholder.js
@@ -19,7 +19,7 @@ export default {
           },
           
           setPlaceholder() {
-              if(!this.siteSettings.composer_template_placeholder_enabled?) {
+              if(!this.siteSettings.composer_template_placeholder_enabled) {
                 return;
               }
               const category = this.model?.category;


### PR DESCRIPTION
Fixes syntax error in `javascripts/discourse/api-initializers/composer-placeholder.js`.

* Changes `composer_template_placeholder_enabled?` to `composer_template_placeholder_enabled` in the `setPlaceholder` method.
* Ensures the `setPlaceholder` method checks the `composer_template_placeholder_enabled` setting correctly.

