### PR TITLE
Fix plugin installation in Discourse

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -9,8 +9,9 @@ enabled_site_setting :composer_template_placeholder_enabled
 
 register_asset 'stylesheets/common/composer-template-placeholder.scss'
 register_asset 'javascripts/discourse/api-initializers/composer-placeholder.js'
-register_asset 'config/locales/client.en.yml'
-register_asset 'config/locales/server.en.yml'
+
+register_locale 'config/locales/client.en.yml'
+register_locale 'config/locales/server.en.yml'
 
 after_initialize do
   # Add any server-side code here if needed


### PR DESCRIPTION
Update `plugin.rb` to use `register_locale` instead of `register_asset` for locale files.

* Remove `register_asset` lines for `config/locales/client.en.yml` and `config/locales/server.en.yml`
* Add `register_locale` lines for `config/locales/client.en.yml` and `config/locales/server.en.yml`

